### PR TITLE
Fixed some parameters in the docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ luigid:
   restart: always
   build: ./luigid/
   expose:
-    - "8082:8082"
+    - "8082"
   links:
     - mysql:mysql
   volumes:
@@ -36,4 +36,4 @@ data:
   image: ubuntu:latest
   volumes:
     - /var/lib/mysql
-  command: true
+  command: 'true'


### PR DESCRIPTION
There were a couple of parameters in the docker-compose.yml file that my machine (Mac OS X 10.11.6, docker-compose 1.16.1) threw errors for.

This PR makes a few small changes to the docker-compose.yml file that shouldn't affect functionality at all.